### PR TITLE
Add haplotype contigs to build37

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script: tox
 deploy:
   provider: pypi
   distributions: sdist
-  user: blopker
+  user: mstrand
   on:
     tags: true
   password:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ SeqSeek [![Build Status](https://travis-ci.org/23andMe/seqseek.svg?branch=master
 =================
 Easy access to Homo sapiens NCBI Build 37 and 38 reference sequences.
 
-This package calls open(file).seek(range) on FASTA files of ASCII to provide
-ranges of sequence strings. It is exactly as fast as your disk, for better or worse.
+This package calls open(file).seek(range) on FASTA files of ASCII characters to provide
+ranges of sequence strings. It is exactly as fast as your disk, for better or worse. 
 
 Requirements
 ------------
@@ -64,4 +64,4 @@ from seqseek import Chromosome, BUILD38
 Chromosome(17, assembly=BUILD38).sequence(start=141224, end=141244) #=> ACCTGGTGAGGGGACATGGG
 ```
 Build 37 is the default. You can specify another build with the assembly option,
-as shown above.
+as shown above. 

--- a/seqseek/chromosome.py
+++ b/seqseek/chromosome.py
@@ -43,7 +43,7 @@ class Chromosome(object):
 
     def validate_name(self):
         if self.name not in self.chromosome_lengths.keys():
-            raise ValueError("{name} is not a valid chromosome name!".format(name=self.name))
+            raise ValueError("{name} is not a valid chromosome name".format(name=self.name))
 
     def validate_coordinates(self, start, end):
         if start < 0 or end < 0:
@@ -85,6 +85,7 @@ class Chromosome(object):
             raise MissingDataError(
                 '{} does not exist. Please download on the command line with: '
                 'download_build_{}'.format(self.path(), build))
+
         with open(self.path()) as fasta:
             # each file has a header like ">chr15" followed by a newline
             fasta.seek(start + len(self.header()))

--- a/seqseek/format_fasta.py
+++ b/seqseek/format_fasta.py
@@ -1,0 +1,24 @@
+import argparse
+
+
+def run(path):
+    print "Formatting %s" % path
+    with open(path) as fasta:
+        header = ''
+        first_line = fasta.readline()
+        if not first_line.startswith('>'):
+            header = '> ' + path.split('/')[-1].split('.')[0] + '\n'
+            first_line.replace('\n', '')
+        clean = fasta.read().replace('\n', '')
+
+    with open(path + '.seqseek', 'w') as formatted:
+        formatted.write(header)
+        formatted.write(first_line)
+        formatted.write(clean)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("fasta_path")
+    args = parser.parse_args()
+    run(args.fasta_path)

--- a/seqseek/format_fasta.py
+++ b/seqseek/format_fasta.py
@@ -16,6 +16,11 @@ def run(path):
         formatted.write(first_line)
         formatted.write(clean)
 
+    with open(path + '.seqseek') as done:
+        done.readline()
+        sequence = done.read()
+        print "Length is %d" % len(sequence)
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/seqseek/lib.py
+++ b/seqseek/lib.py
@@ -4,37 +4,42 @@ import os
 
 BUILD37 = 'homo_sapiens_GRCh37'
 BUILD38 = 'homo_sapiens_GRCh38'
+
+DEFAULT_DATA_DIR = '~/.seqseek'
 DATA_DIR_VARIABLE = 'SEQSEEK_DATA_DIR'
+
 URI37 = 'https://s3-us-west-2.amazonaws.com/seqseek/homo_sapiens_GRCh37/'
 URI38 = 'https://s3-us-west-2.amazonaws.com/seqseek/homo_sapiens_GRCh38/'
 
 # chromosome names and lengths for build 37
 BUILD37_CHROMOSOMES = {
-        '1': 249250621,
-        '2': 243199373,
-        '3': 198022430,
-        '4': 191154276,
-        '5': 180915260,
-        '6': 171115067,
-        '7': 159138663,
-        '8': 146364022,
-        '9': 141213431,
-        '10': 135534747,
-        '11': 135006516,
-        '12': 133851895,
-        '13': 115169878,
-        '14': 107349540,
-        '15': 102531392,
-        '16': 90354753,
-        '17': 81195210,
-        '18': 78077248,
-        '19': 59128983,
-        '20': 63025520,
-        '21': 48129895,
-        '22': 51304566,
-        'X':  155270560,
-        'Y':  59373566,
-        'MT':  16571
+    '1': 249250621,
+    '2': 243199373,
+    '3': 198022430,
+    '4': 191154276,
+    '5': 180915260,
+    '6': 171115067,
+    '7': 159138663,
+    '8': 146364022,
+    '9': 141213431,
+    '10': 135534747,
+    '11': 135006516,
+    '12': 133851895,
+    '13': 115169878,
+    '14': 107349540,
+    '15': 102531392,
+    '16': 90354753,
+    '17': 81195210,
+    '18': 78077248,
+    '19': 59128983,
+    '20': 63025520,
+    '21': 48129895,
+    '22': 51304566,
+    'X':  155270560,
+    'Y':  59373566,
+    'MT':  16571,
+    '6_cox_hap2': 4795371
+
 }
 
 # chromosome names and lengths for build 38
@@ -68,12 +73,13 @@ BUILD38_CHROMOSOMES = {
 
 
 def get_data_directory():
-    default = os.path.expanduser('~/.seqseek')
+    default = os.path.expanduser(DEFAULT_DATA_DIR)
     storage_dir = os.environ.get('DATA_DIR_VARIABLE', default)
     os.environ[DATA_DIR_VARIABLE] = storage_dir
     if not os.path.exists(storage_dir):
         os.makedirs(storage_dir)
     return storage_dir
+
 
 def sorted_nicely(l):
     """

--- a/seqseek/lib.py
+++ b/seqseek/lib.py
@@ -42,6 +42,7 @@ BUILD37_CHROMOSOMES = {
     '6_apd_hap1': 4622290,
     '6_ssto_hap7': 4928567,
     '6_mcf_hap5': 4833398,
+    '6_qbl_hap6': 4611984,
 }
 
 # chromosome names and lengths for build 38

--- a/seqseek/lib.py
+++ b/seqseek/lib.py
@@ -38,8 +38,8 @@ BUILD37_CHROMOSOMES = {
     'X':  155270560,
     'Y':  59373566,
     'MT':  16571,
-    '6_cox_hap2': 4795371
-
+    '6_cox_hap2': 4795371,
+    '6_apd_hap1': 4622290
 }
 
 # chromosome names and lengths for build 38

--- a/seqseek/lib.py
+++ b/seqseek/lib.py
@@ -38,11 +38,14 @@ BUILD37_CHROMOSOMES = {
     'X':  155270560,
     'Y':  59373566,
     'MT':  16571,
-    '6_cox_hap2': 4795371,
+
+    # Haplotype contigs
     '6_apd_hap1': 4622290,
-    '6_ssto_hap7': 4928567,
+    '6_cox_hap2': 4795371,
+    '6_mann_hap4': 4683263,
     '6_mcf_hap5': 4833398,
     '6_qbl_hap6': 4611984,
+    '6_ssto_hap7': 4928567,
 }
 
 # chromosome names and lengths for build 38

--- a/seqseek/lib.py
+++ b/seqseek/lib.py
@@ -41,6 +41,7 @@ BUILD37_CHROMOSOMES = {
     '6_cox_hap2': 4795371,
     '6_apd_hap1': 4622290,
     '6_ssto_hap7': 4928567,
+    '6_mcf_hap5': 4833398,
 }
 
 # chromosome names and lengths for build 38

--- a/seqseek/lib.py
+++ b/seqseek/lib.py
@@ -42,11 +42,12 @@ BUILD37_CHROMOSOMES = {
     # Haplotype contigs
     '6_apd_hap1': 4622290,
     '6_cox_hap2': 4795371,
+    '6_dbb_hap3': 4610396,
     '6_mann_hap4': 4683263,
     '6_mcf_hap5': 4833398,
     '6_qbl_hap6': 4611984,
     '6_ssto_hap7': 4928567,
-    '6_dbb_hap3': 4610396,
+    '17_ctg5_hap1': 1680828,
 }
 
 # chromosome names and lengths for build 38

--- a/seqseek/lib.py
+++ b/seqseek/lib.py
@@ -39,7 +39,8 @@ BUILD37_CHROMOSOMES = {
     'Y':  59373566,
     'MT':  16571,
     '6_cox_hap2': 4795371,
-    '6_apd_hap1': 4622290
+    '6_apd_hap1': 4622290,
+    '6_ssto_hap7': 4928567,
 }
 
 # chromosome names and lengths for build 38

--- a/seqseek/lib.py
+++ b/seqseek/lib.py
@@ -46,6 +46,7 @@ BUILD37_CHROMOSOMES = {
     '6_mcf_hap5': 4833398,
     '6_qbl_hap6': 4611984,
     '6_ssto_hap7': 4928567,
+    '6_dbb_hap3': 4610396,
 }
 
 # chromosome names and lengths for build 38

--- a/seqseek/tests/build_specific_tests/build_37_tests.py
+++ b/seqseek/tests/build_specific_tests/build_37_tests.py
@@ -14,7 +14,7 @@ class TestBuild37(TestCase):
 
     def test_file_count(self):
         file_count = len(fnmatch.filter(os.listdir(TestBuild37.GRCH37_PATH), '*.fa'))
-        self.assertEqual(file_count, 26)
+        self.assertEqual(file_count, 27)
 
     def test_file_names(self):
         for name in BUILD37_CHROMOSOMES.keys():
@@ -26,7 +26,7 @@ class TestBuild37(TestCase):
     # chromosome browser tool
 
     def test_chr_start_sequences(self):
-        exclude = ('MT', '17' , '6_cox_hap2')
+        exclude = ('MT', '17' , '6_cox_hap2', '6_apd_hap1')
         test_str = "N" * 20
         for name in BUILD37_CHROMOSOMES.keys():
             # these chromosomes do not have telomeres
@@ -175,4 +175,18 @@ class TestBuild37(TestCase):
 
         expected = "tc"
         seq = Chromosome('6_cox_hap2').sequence(4795369, BUILD37_CHROMOSOMES['6_cox_hap2'])
+        self.assertEqual(expected, seq)
+
+    def test_chr6_apd_hap1(self):
+        expected = "GAATTCAGCTCGCCGACGGC"
+        seq = Chromosome('6_apd_hap1').sequence(0, 20)
+        self.assertEqual(expected, seq)
+
+        expected = "ACAATTAGAAATACTAGGAG"
+        seq = Chromosome('6_apd_hap1').sequence(3000, 3020)
+        self.assertEqual(expected, seq)
+
+        expected = "cacT"
+        seq = Chromosome('6_apd_hap1').sequence(BUILD37_CHROMOSOMES['6_apd_hap1'] - 4,
+                                                BUILD37_CHROMOSOMES['6_apd_hap1'])
         self.assertEqual(expected, seq)

--- a/seqseek/tests/build_specific_tests/build_37_tests.py
+++ b/seqseek/tests/build_specific_tests/build_37_tests.py
@@ -3,18 +3,18 @@ import fnmatch
 
 from seqseek.chromosome import Chromosome
 
-from seqseek.lib import get_data_directory, BUILD37_CHROMOSOMES, BUILD37
+from seqseek.lib import get_data_directory, BUILD37_CHROMOSOMES
 
 from unittest import TestCase
 
-# pragma: no cover
+
 class TestBuild37(TestCase):
 
     GRCH37_PATH = os.path.join(get_data_directory(), 'homo_sapiens_GRCh37')
 
     def test_file_count(self):
         file_count = len(fnmatch.filter(os.listdir(TestBuild37.GRCH37_PATH), '*.fa'))
-        self.assertEqual(file_count, 25)
+        self.assertEqual(file_count, 26)
 
     def test_file_names(self):
         for name in BUILD37_CHROMOSOMES.keys():
@@ -26,10 +26,11 @@ class TestBuild37(TestCase):
     # chromosome browser tool
 
     def test_chr_start_sequences(self):
+        exclude = ('MT', '17' , '6_cox_hap2')
         test_str = "N" * 20
         for name in BUILD37_CHROMOSOMES.keys():
             # these chromosomes do not have telomeres
-            if name == 'MT'or name == '17':
+            if name in exclude:
                 continue
             seq = Chromosome(name).sequence(0, 20)
             self.assertEqual(seq, test_str)
@@ -158,3 +159,20 @@ class TestBuild37(TestCase):
         expected_seq = "TATTGTACGGTACCATAAAT"
         seq = Chromosome("MT").sequence(16121, 16141)
         self.assertEqual(expected_seq, seq)
+
+    def test_chr6_cox_hap2(self):
+        expected_seq = "GATCCTGAGTGGGTGAGTGG"
+        seq = Chromosome("6_cox_hap2").sequence(3065395, 3065415)
+        self.assertEqual(expected_seq, seq)
+
+        expected_seq = "TATTCTTGCCAATAT"
+        seq = Chromosome("6_cox_hap2").sequence(200, 215).upper()
+        self.assertEqual(expected_seq, seq)
+
+        expected_seq = "TCTGGCCTGGGAGTC"
+        seq = Chromosome("6_cox_hap2").sequence(0, 15).upper()
+        self.assertEqual(expected_seq, seq)
+
+        expected = "tc"
+        seq = Chromosome('6_cox_hap2').sequence(4795369, BUILD37_CHROMOSOMES['6_cox_hap2'])
+        self.assertEqual(expected, seq)

--- a/seqseek/tests/build_specific_tests/build_37_tests.py
+++ b/seqseek/tests/build_specific_tests/build_37_tests.py
@@ -14,7 +14,7 @@ class TestBuild37(TestCase):
 
     def test_file_count(self):
         file_count = len(fnmatch.filter(os.listdir(TestBuild37.GRCH37_PATH), '*.fa'))
-        self.assertEqual(file_count, 31)
+        self.assertEqual(file_count, 32)
 
     def test_file_names(self):
         for name in BUILD37_CHROMOSOMES.keys():
@@ -27,7 +27,7 @@ class TestBuild37(TestCase):
 
     def test_chr_start_sequences(self):
         exclude = ('MT', '17' , '6_cox_hap2', '6_apd_hap1', '6_ssto_hap7', '6_mcf_hap5',
-                   '6_qbl_hap6', '6_mann_hap4')
+                   '6_qbl_hap6', '6_mann_hap4', '6_dbb_hap3')
         test_str = "N" * 20
         for name in BUILD37_CHROMOSOMES.keys():
             # these chromosomes do not have telomeres
@@ -213,11 +213,16 @@ class TestBuild37(TestCase):
         self.assertEqual(expected, seq)
 
         expected = "ggcc"
-        seq = Chromosome('6_qbl_hap6').sequence(BUILD37_CHROMOSOMES['6_qbl_hap6'] - 4 ,
+        seq = Chromosome('6_qbl_hap6').sequence(BUILD37_CHROMOSOMES['6_qbl_hap6'] - 4,
                                                 BUILD37_CHROMOSOMES['6_qbl_hap6'])
         self.assertEqual(expected, seq)
 
     def test_chr6_mann_hap4(self):
         expected = "ACAATTAGAAATACTAGGAG"
         seq = Chromosome('6_mann_hap4').sequence(3000, 3020)
+        self.assertEqual(expected, seq)
+
+    def test_chr6_dbb_hap3(self):
+        expected = "ACAATTAGAAATACTAGGAG"
+        seq = Chromosome('6_dbb_hap3').sequence(3000, 3020)
         self.assertEqual(expected, seq)

--- a/seqseek/tests/build_specific_tests/build_37_tests.py
+++ b/seqseek/tests/build_specific_tests/build_37_tests.py
@@ -14,7 +14,7 @@ class TestBuild37(TestCase):
 
     def test_file_count(self):
         file_count = len(fnmatch.filter(os.listdir(TestBuild37.GRCH37_PATH), '*.fa'))
-        self.assertEqual(file_count, 27)
+        self.assertEqual(file_count, 28)
 
     def test_file_names(self):
         for name in BUILD37_CHROMOSOMES.keys():
@@ -26,7 +26,7 @@ class TestBuild37(TestCase):
     # chromosome browser tool
 
     def test_chr_start_sequences(self):
-        exclude = ('MT', '17' , '6_cox_hap2', '6_apd_hap1')
+        exclude = ('MT', '17' , '6_cox_hap2', '6_apd_hap1', '6_ssto_hap7')
         test_str = "N" * 20
         for name in BUILD37_CHROMOSOMES.keys():
             # these chromosomes do not have telomeres
@@ -189,4 +189,14 @@ class TestBuild37(TestCase):
         expected = "cacT"
         seq = Chromosome('6_apd_hap1').sequence(BUILD37_CHROMOSOMES['6_apd_hap1'] - 4,
                                                 BUILD37_CHROMOSOMES['6_apd_hap1'])
+        self.assertEqual(expected, seq)
+
+    def test_chr6_ssto_hap7(self):
+        expected = "GGCCAGGTTTTGTGAATTCT"
+        seq = Chromosome('6_ssto_hap7').sequence(3000, 3020)
+        self.assertEqual(expected, seq)
+
+        expected = "ggcc"
+        seq = Chromosome('6_ssto_hap7').sequence(BUILD37_CHROMOSOMES['6_ssto_hap7'] - 4,
+                                                BUILD37_CHROMOSOMES['6_ssto_hap7'])
         self.assertEqual(expected, seq)

--- a/seqseek/tests/build_specific_tests/build_37_tests.py
+++ b/seqseek/tests/build_specific_tests/build_37_tests.py
@@ -14,7 +14,7 @@ class TestBuild37(TestCase):
 
     def test_file_count(self):
         file_count = len(fnmatch.filter(os.listdir(TestBuild37.GRCH37_PATH), '*.fa'))
-        self.assertEqual(file_count, 30)
+        self.assertEqual(file_count, 31)
 
     def test_file_names(self):
         for name in BUILD37_CHROMOSOMES.keys():
@@ -27,7 +27,7 @@ class TestBuild37(TestCase):
 
     def test_chr_start_sequences(self):
         exclude = ('MT', '17' , '6_cox_hap2', '6_apd_hap1', '6_ssto_hap7', '6_mcf_hap5',
-                   '6_qbl_hap6')
+                   '6_qbl_hap6', '6_mann_hap4')
         test_str = "N" * 20
         for name in BUILD37_CHROMOSOMES.keys():
             # these chromosomes do not have telomeres
@@ -215,4 +215,9 @@ class TestBuild37(TestCase):
         expected = "ggcc"
         seq = Chromosome('6_qbl_hap6').sequence(BUILD37_CHROMOSOMES['6_qbl_hap6'] - 4 ,
                                                 BUILD37_CHROMOSOMES['6_qbl_hap6'])
+        self.assertEqual(expected, seq)
+
+    def test_chr6_mann_hap4(self):
+        expected = "ACAATTAGAAATACTAGGAG"
+        seq = Chromosome('6_mann_hap4').sequence(3000, 3020)
         self.assertEqual(expected, seq)

--- a/seqseek/tests/build_specific_tests/build_37_tests.py
+++ b/seqseek/tests/build_specific_tests/build_37_tests.py
@@ -14,7 +14,7 @@ class TestBuild37(TestCase):
 
     def test_file_count(self):
         file_count = len(fnmatch.filter(os.listdir(TestBuild37.GRCH37_PATH), '*.fa'))
-        self.assertEqual(file_count, 28)
+        self.assertEqual(file_count, 29)
 
     def test_file_names(self):
         for name in BUILD37_CHROMOSOMES.keys():
@@ -26,7 +26,7 @@ class TestBuild37(TestCase):
     # chromosome browser tool
 
     def test_chr_start_sequences(self):
-        exclude = ('MT', '17' , '6_cox_hap2', '6_apd_hap1', '6_ssto_hap7')
+        exclude = ('MT', '17' , '6_cox_hap2', '6_apd_hap1', '6_ssto_hap7', '6_mcf_hap5')
         test_str = "N" * 20
         for name in BUILD37_CHROMOSOMES.keys():
             # these chromosomes do not have telomeres
@@ -199,4 +199,9 @@ class TestBuild37(TestCase):
         expected = "ggcc"
         seq = Chromosome('6_ssto_hap7').sequence(BUILD37_CHROMOSOMES['6_ssto_hap7'] - 4,
                                                 BUILD37_CHROMOSOMES['6_ssto_hap7'])
+        self.assertEqual(expected, seq)
+
+    def test_chr6_mcf_hap5(self):
+        expected = "ACAATTAGAAATACTAGGAG"
+        seq = Chromosome('6_mcf_hap5').sequence(3000, 3020)
         self.assertEqual(expected, seq)

--- a/seqseek/tests/build_specific_tests/build_37_tests.py
+++ b/seqseek/tests/build_specific_tests/build_37_tests.py
@@ -14,7 +14,7 @@ class TestBuild37(TestCase):
 
     def test_file_count(self):
         file_count = len(fnmatch.filter(os.listdir(TestBuild37.GRCH37_PATH), '*.fa'))
-        self.assertEqual(file_count, 29)
+        self.assertEqual(file_count, 30)
 
     def test_file_names(self):
         for name in BUILD37_CHROMOSOMES.keys():
@@ -26,7 +26,8 @@ class TestBuild37(TestCase):
     # chromosome browser tool
 
     def test_chr_start_sequences(self):
-        exclude = ('MT', '17' , '6_cox_hap2', '6_apd_hap1', '6_ssto_hap7', '6_mcf_hap5')
+        exclude = ('MT', '17' , '6_cox_hap2', '6_apd_hap1', '6_ssto_hap7', '6_mcf_hap5',
+                   '6_qbl_hap6')
         test_str = "N" * 20
         for name in BUILD37_CHROMOSOMES.keys():
             # these chromosomes do not have telomeres
@@ -204,4 +205,14 @@ class TestBuild37(TestCase):
     def test_chr6_mcf_hap5(self):
         expected = "ACAATTAGAAATACTAGGAG"
         seq = Chromosome('6_mcf_hap5').sequence(3000, 3020)
+        self.assertEqual(expected, seq)
+
+    def test_chr6_qbl_hap6(self):
+        expected = "ACAATTAGAAATACTAGGAG"
+        seq = Chromosome('6_qbl_hap6').sequence(3000, 3020)
+        self.assertEqual(expected, seq)
+
+        expected = "ggcc"
+        seq = Chromosome('6_qbl_hap6').sequence(BUILD37_CHROMOSOMES['6_qbl_hap6'] - 4 ,
+                                                BUILD37_CHROMOSOMES['6_qbl_hap6'])
         self.assertEqual(expected, seq)

--- a/seqseek/tests/build_specific_tests/build_37_tests.py
+++ b/seqseek/tests/build_specific_tests/build_37_tests.py
@@ -14,7 +14,7 @@ class TestBuild37(TestCase):
 
     def test_file_count(self):
         file_count = len(fnmatch.filter(os.listdir(TestBuild37.GRCH37_PATH), '*.fa'))
-        self.assertEqual(file_count, 32)
+        self.assertEqual(file_count, 33)
 
     def test_file_names(self):
         for name in BUILD37_CHROMOSOMES.keys():
@@ -27,7 +27,7 @@ class TestBuild37(TestCase):
 
     def test_chr_start_sequences(self):
         exclude = ('MT', '17' , '6_cox_hap2', '6_apd_hap1', '6_ssto_hap7', '6_mcf_hap5',
-                   '6_qbl_hap6', '6_mann_hap4', '6_dbb_hap3')
+                   '6_qbl_hap6', '6_mann_hap4', '6_dbb_hap3', '17_ctg5_hap1')
         test_str = "N" * 20
         for name in BUILD37_CHROMOSOMES.keys():
             # these chromosomes do not have telomeres
@@ -225,4 +225,9 @@ class TestBuild37(TestCase):
     def test_chr6_dbb_hap3(self):
         expected = "ACAATTAGAAATACTAGGAG"
         seq = Chromosome('6_dbb_hap3').sequence(3000, 3020)
+        self.assertEqual(expected, seq)
+
+    def test_chr17_ctg5_hap1(self):
+        expected = "TTTTGGCTACAATAATTCTT"
+        seq = Chromosome('17_ctg5_hap1').sequence(3000, 3020)
         self.assertEqual(expected, seq)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     url='https://github.com/23andMe/seqseek',
     download_url = 'https://github.com/23andMe/seqseek/tarball/0.1.10',
     author='23andMe Engineering',
-    author_email=['jelofson@23andme.com', 'mstrand@23anmde.com'],
+    author_email=['mstrand@23anmde.com'],
     description='Easy access to Build 37 & 38 human reference sequences',
     long_description=readme,
     entry_points={'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ elif PY3:
 
 setup(
     name='seqseek',
-    version='0.1.10',
+    version='0.2.0',
     url='https://github.com/23andMe/seqseek',
     download_url = 'https://github.com/23andMe/seqseek/tarball/0.1.10',
     author='23andMe Engineering',


### PR DESCRIPTION
Many mutations in the MHC & HLA regions are mapped to haplotypes that differ from the reference GRCh37 reference contigs. Databases such as dbsnp often report the mutations on these haplotype contigs and adding them to seqseek allows for a more seamless rsid -> coordinates -> sequence workflow. 
