### PR TITLE
Feature/circular mito

### DIFF
--- a/seqseek/chromosome.py
+++ b/seqseek/chromosome.py
@@ -31,7 +31,7 @@ class Chromosome(object):
         self.name = str(chromosome_name)
         self.assembly = assembly
         self.validate_assembly()
-        self.chromosome_lengths = Chromosome.ASSEMBLY_CHROMOSOMES[self.assembly]
+        self.chromosome_lengths = self.ASSEMBLY_CHROMOSOMES[self.assembly]
         self.validate_name()
         self.length = self.chromosome_lengths[self.name]
 
@@ -45,12 +45,14 @@ class Chromosome(object):
         if self.name not in self.chromosome_lengths.keys():
             raise ValueError("{name} is not a valid chromosome name".format(name=self.name))
 
-    def validate_coordinates(self, start, end):
+    def validate_coordinates(self, start, end, loop=False):
+        if loop and self.name != 'MT':
+            raise ValueError('Loop may only be specified for the mitochondria.')
         if start < 0 or end < 0:
             raise ValueError("Start and end must be positive integers")
         if end < start:
             raise ValueError("Start position cannot be greater than end position")
-        if start > self.length or end > self.length:
+        if start > self.length or (end > self.length and not loop):
             raise ValueError('Coordinates out of bounds. Chr {} has {} bases.'.format(
                 self.name, self.length))
 
@@ -76,9 +78,20 @@ class Chromosome(object):
         header_name = self.name if self.name != 'MT' else 'M'
         return ">chr" + header_name + "\n"
 
-    def sequence(self, start, end):
-        self.validate_coordinates(start, end)
-        seq_length = end - start
+    def read(self, start, length):
+        with open(self.path()) as fasta:
+            header = fasta.readline()
+            fasta.seek(start + len(header))
+            return fasta.read(length)
+
+    def sequence(self, start, end, loop=False):
+        self.validate_coordinates(start, end, loop=loop)
+
+        if loop and end > self.length:
+            # deal with looping around circular mito
+            reads = [(start, self.length - start), (0, end - self.length)]
+        else:
+            reads = [(start, end - start)]
 
         if not self.exists():
             build = '37' if self.assembly == BUILD37 else '38'
@@ -86,7 +99,4 @@ class Chromosome(object):
                 '{} does not exist. Please download on the command line with: '
                 'download_build_{}'.format(self.path(), build))
 
-        with open(self.path()) as fasta:
-            # each file has a header like ">chr15" followed by a newline
-            fasta.seek(start + len(self.header()))
-            return fasta.read(seq_length)
+        return ''.join([self.read(*read) for read in reads])

--- a/seqseek/exceptions.py
+++ b/seqseek/exceptions.py
@@ -1,0 +1,2 @@
+class TooManyLoops(Exception):
+    pass

--- a/seqseek/lib.py
+++ b/seqseek/lib.py
@@ -37,7 +37,7 @@ BUILD37_CHROMOSOMES = {
     '22': 51304566,
     'X':  155270560,
     'Y':  59373566,
-    'MT':  16571,
+    'MT': 16571,
 
     # Haplotype contigs
     '6_apd_hap1': 4622290,

--- a/seqseek/tests/build_specific_tests/build_37_tests.py
+++ b/seqseek/tests/build_specific_tests/build_37_tests.py
@@ -231,3 +231,9 @@ class TestBuild37(TestCase):
         expected = "TTTTGGCTACAATAATTCTT"
         seq = Chromosome('17_ctg5_hap1').sequence(3000, 3020)
         self.assertEqual(expected, seq)
+
+    def test_looped_mito(self):
+        mito_length = BUILD37_CHROMOSOMES['MT']
+        expected = 'CATCACGATGGATCACAGGT'
+        seq = Chromosome('MT').sequence(mito_length - 10, mito_length + 10, loop=True)
+        self.assertEqual(expected, seq)

--- a/seqseek/tests/build_specific_tests/build_38_tests.py
+++ b/seqseek/tests/build_specific_tests/build_38_tests.py
@@ -158,3 +158,9 @@ class TestBuild38(TestCase):
         expected_seq = "ATTGTACGGTACCATAAATA"
         seq = Chromosome("MT", assembly=BUILD38).sequence(16121, 16141)
         self.assertEqual(expected_seq, seq)
+
+    def test_looped_mito(self):
+        mito_length = BUILD38_CHROMOSOMES['MT']
+        expected = 'CATCACGATGGATCACAGGT'
+        seq = Chromosome('MT', BUILD38).sequence(mito_length - 10, mito_length + 10, loop=True)
+        self.assertEqual(expected, seq)


### PR DESCRIPTION
The mitochondria is a circular piece of DNA and it is sometimes useful to retrieve sequences that extend beyond the min or max coordinates of the contig and loop back to the beginning or end. This is mainly useful for pulling flanking sequences for designing oligonucleotide probes near the extreme 3' and 5' regions of the mitochondria but there may be other applications as well. 

We never return sequences that are longer than the length of the contig. Attempts to load such a sequence raise a `TooManyLoops` exception

This behavior can be requested by passing loop=True to the sequence() function of and 'MT' chromosome object:

```
Chromosome('MT').sequence(-10, 10, loop=True)
```
