### PR TITLE
Allow loading by accession and add the RSRS mito accession

### DIFF
--- a/seqseek/chromosome.py
+++ b/seqseek/chromosome.py
@@ -49,8 +49,8 @@ class Chromosome(object):
                     BUILD37, BUILD38))
 
     def validate_name(self):
-        if self.name not in self.ASSEMBLY_CHROMOSOMES[self.assembly]:
-            if self.name not in ACCESSION_LENGTHS:
+        if self.name not in ACCESSION_LENGTHS:
+            if self.name not in self.ASSEMBLY_CHROMOSOMES[self.assembly]:
                 raise ValueError(
                     "{name} is not a valid chromosome name or accession".format(
                         name=self.name))

--- a/seqseek/chromosome.py
+++ b/seqseek/chromosome.py
@@ -33,7 +33,13 @@ class Chromosome(object):
         self.validate_name()
         self.validate_loop()
 
-        self.accession = self.ASSEMBLY_CHROMOSOMES[assembly][self.name]
+        if self.name in ACCESSION_LENGTHS:
+            # allow loading by accession
+            self.accession = self.name
+        else:
+            # allow loading by name
+            self.accession = self.ASSEMBLY_CHROMOSOMES[assembly][self.name]
+
         self.length = ACCESSION_LENGTHS[self.accession]
 
     def validate_assembly(self):
@@ -44,7 +50,10 @@ class Chromosome(object):
 
     def validate_name(self):
         if self.name not in self.ASSEMBLY_CHROMOSOMES[self.assembly]:
-            raise ValueError("{name} is not a valid chromosome name".format(name=self.name))
+            if self.name not in ACCESSION_LENGTHS:
+                raise ValueError(
+                    "{name} is not a valid chromosome name or accession".format(
+                        name=self.name))
 
     def validate_loop(self):
         if self.loop and self.name != 'MT':

--- a/seqseek/lib.py
+++ b/seqseek/lib.py
@@ -39,8 +39,9 @@ BUILD37_ACCESSIONS = {
     'X': 'NC_000023.10',
     'Y': 'NC_000024.9',
     'MT': 'NC_012920.1',
+    'RSRS': 'NC_001807.4',
 
-    # UCSC names for haplotype contigs
+    # UCSC names for haplotype scaffolds
     'chr6_apd_hap1': 'NT_167244.1',
     'chr6_cox_hap2': 'NT_113891.2',
     'chr6_dbb_hap3': 'NT_167245.1',
@@ -78,6 +79,7 @@ BUILD38_ACCESSIONS = {
     'X': 'NC_000023.11',
     'Y': 'NC_000024.10',
     'MT': 'NC_012920.1',
+    'RSRS': 'NC_001807.4',
 }
 
 # chromosome names and lengths for build 37
@@ -135,9 +137,10 @@ ACCESSION_LENGTHS = {
     'NC_000024.9':   59373566,
 
     # Mito is shared between 37 & 38
-    'NC_012920.1':   16569,
+    'NC_012920.1':   16569,  # rCRS
+    'NC_001807.4':   16571,  # RSRS
 
-    # Haplotype contigs
+    # Haplotype scaffolds
     'NT_113891.2': 4795371,
     'NT_167244.1': 4622290,
     'NT_167245.1': 4610396,
@@ -170,7 +173,7 @@ def sorted_nicely(l):
 
 
 """
-The nine haplotype chromosomes are:
+The nine haplotype scaffolds are:
     name                    accession       UCSC chr name
     HSCHR6_MHC_APD_CTG1     GL000250.1      chr6_apd_hap1
     HSCHR6_MHC_COX_CTG1     GL000251.1      chr6_cox_hap2

--- a/seqseek/tests/build_specific_tests/build_37_tests.py
+++ b/seqseek/tests/build_specific_tests/build_37_tests.py
@@ -20,7 +20,7 @@ class TestBuild37(TestCase):
     def test_chr_start_sequences(self):
         exclude = ('MT', '17' , 'chr6_cox_hap2', 'chr6_apd_hap1', 'chr6_ssto_hap7',
                    'chr6_mcf_hap5', 'chr6_qbl_hap6', 'chr6_mann_hap4', 'chr6_dbb_hap3',
-                   'chr17_ctg5_hap1', 'chr4_ctg9_hap1')
+                   'chr17_ctg5_hap1', 'chr4_ctg9_hap1', 'RSRS')
         test_str = "N" * 20
         for name in BUILD37_ACCESSIONS.keys():
             # these chromosomes do not have telomeres
@@ -256,3 +256,8 @@ class TestBuild37(TestCase):
         not actually part of the observed sequence.
         """
         self.assertEqual('', Chromosome('MT').sequence(3106, 3107))
+
+    def test_RSRS(self):
+        expected = 'GGAC'
+        seq = Chromosome('NC_001807.4').sequence(750, 754)
+        self.assertEqual(expected, seq)

--- a/seqseek/tests/build_specific_tests/build_38_tests.py
+++ b/seqseek/tests/build_specific_tests/build_38_tests.py
@@ -17,10 +17,9 @@ class TestBuild38(TestCase):
         self.assertEqual(file_count, 25)
 
     def test_file_names(self):
-        for name in BUILD38_ACCESSIONS.keys():
-            fasta = os.path.join(TestBuild38.GRCH38_PATH,
-                                 "chr" + str(name) + ".fa")
-            self.assertTrue(os.path.isfile(fasta))
+        for accession in BUILD38_ACCESSIONS.values():
+            fasta = os.path.join(get_data_directory(), str(accession) + ".fa")
+            self.assertTrue(os.path.isfile(fasta), fasta)
 
     # all test sequences were extracted from https://genome.ucsc.edu/ using the
     # chromosome browser tool
@@ -29,7 +28,7 @@ class TestBuild38(TestCase):
         test_str = "N" * 20
         for name in BUILD38_ACCESSIONS.keys():
             # these chromosomes do not have telomeres
-            if name == 'MT'or name == '17':
+            if name in ('MT', 'RSRS', '17'):
                 continue
             seq = Chromosome(name, assembly=BUILD38).sequence(0, 20)
             self.assertEqual(seq, test_str)
@@ -181,3 +180,8 @@ class TestBuild38(TestCase):
         not actually part of the observed sequence.
         """
         self.assertEqual('', Chromosome('MT').sequence(3106, 3107))
+
+    def test_RSRS(self):
+        expected = 'GGAC'
+        seq = Chromosome('NC_001807.4').sequence(750, 754)
+        self.assertEqual(expected, seq)

--- a/seqseek/tests/test_functional.py
+++ b/seqseek/tests/test_functional.py
@@ -96,6 +96,16 @@ class TestChromosome(TestCase):
         with self.assertRaises(TooManyLoops):
             Chromosome('MT', loop=True).sequence(-1, mt_length)
 
+    def test_load_by_accession(self):
+        # mostly duped from test_chr1_sequences
+        expected_seq = 'GGGGCGGGAGGACGGGCCCG'
+        seq = Chromosome('NC_000001.10').sequence(0, 20)
+        self.assertEqual(seq, expected_seq)
+        self.assertEqual(len(seq), 20)
+        expected_seq = 'GGGAG'
+        seq = Chromosome('NC_000001.10').sequence(5, 10)
+        self.assertEqual(seq, expected_seq)
+
 
 class TestInvalidQueries(TestCase):
 


### PR DESCRIPTION
Adding the ability to load directly by accession so if you know the accession you don't have to use the common name + assembly. Also adding the outdated RSRS mitochondria sequence for so that I can document a workaround to our backwards-incompatible change to use rCRS mito. 
