### PR TITLE
Add Python 3 support without breaking Python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ranges of sequence strings. It is exactly as fast as your disk, for better or wo
 
 Requirements
 ------------
-* Python 2.7+
+* Python 2.7+ or Python 3.4+
 
 Install
 -------

--- a/seqseek/__init__.py
+++ b/seqseek/__init__.py
@@ -1,4 +1,5 @@
+from __future__ import absolute_import
 
-from chromosome import Chromosome
+from .chromosome import Chromosome
 
-from lib import BUILD37, BUILD38
+from .lib import BUILD37, BUILD38

--- a/seqseek/downloader.py
+++ b/seqseek/downloader.py
@@ -1,11 +1,13 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 import argparse
 import requests
 
-from lib import get_data_directory, URI, BUILD37, BUILD38
-from chromosome import Chromosome
+from .lib import get_data_directory, URI, BUILD37, BUILD38
+from .chromosome import Chromosome
 
-from tests.build_specific_tests import run_build_test_suite
+from .tests.build_specific_tests import run_build_test_suite
 
 PROGRAM_TO_ASSEMBLY = {
     'download_build_37': BUILD37,
@@ -42,7 +44,7 @@ class Downloader(object):
 
     def log(self, msg, force=False):
         if self.verbose or force:
-            print msg  # TODO: add a log handler
+            print(msg)  # TODO: add a log handler
 
     def validate_assembly(self):
         if self.assembly not in self.SUPPORTED_ASSEMBLIES:

--- a/seqseek/format_fasta.py
+++ b/seqseek/format_fasta.py
@@ -1,8 +1,9 @@
+from __future__ import print_function
 import argparse
 
 
 def run(path):
-    print "Formatting %s" % path
+    print("Formatting %s" % path)
     with open(path) as fasta:
         header = ''
         first_line = fasta.readline()
@@ -19,7 +20,7 @@ def run(path):
     with open(path + '.seqseek') as done:
         done.readline()
         sequence = done.read()
-        print "Length is %d" % len(sequence)
+        print("Length is %d" % len(sequence))
 
 
 if __name__ == '__main__':

--- a/seqseek/tests/build_specific_tests/__init__.py
+++ b/seqseek/tests/build_specific_tests/__init__.py
@@ -1,1 +1,2 @@
-from build_specific_tests import run_build_test_suite, test_build_38, test_build_37
+from __future__ import absolute_import
+from .build_specific_tests import run_build_test_suite, test_build_38, test_build_37

--- a/seqseek/tests/build_specific_tests/build_specific_tests.py
+++ b/seqseek/tests/build_specific_tests/build_specific_tests.py
@@ -1,7 +1,9 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import unittest
 from seqseek.lib import BUILD37, BUILD38
-from build_37_tests import TestBuild37
-from build_38_tests import TestBuild38
+from .build_37_tests import TestBuild37
+from .build_38_tests import TestBuild38
 
 
 ASSEMBLY_TEST_SUITE = {
@@ -10,7 +12,7 @@ ASSEMBLY_TEST_SUITE = {
 }
 
 def run_build_test_suite(assembly):
-    print "Running tests for {assembly}".format(assembly=assembly)
+    print("Running tests for {assembly}".format(assembly=assembly))
     suite = unittest.TestLoader().loadTestsFromTestCase(ASSEMBLY_TEST_SUITE[assembly])
     unittest.TextTestRunner(verbosity=3).run(suite)
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
-        #'Programming Language :: Python :: 3',
-        #'Programming Language :: Python :: 3.4'
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4'
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,11 @@
 [tox]
-envlist = py27
+envlist = py27, py3
 
 [testenv]
 commands = py.test --cov seqseek --cov-report term-missing seqseek
 deps =
   pytest
   pytest-cov
+basepython =
+    py27: python2.7
+    py3: python3


### PR DESCRIPTION
There is a py3 branch as well, but importing new functions from `__future__` is the correct way to port this to Py3.